### PR TITLE
Refine Water Wave Sound effect

### DIFF
--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -4838,6 +4838,60 @@ uint16_t mode_FlowStripe(void) {
 static const char _data_FX_MODE_FLOWSTRIPE[] PROGMEM = "Flow Stripe@Hue speed,Effect speed;;!;pal=11";
 
 
+//////////////////////////////
+//  Water Wave Sound        //
+//////////////////////////////
+uint16_t mode_water_wave_sound(void) {
+  um_data_t *um_data = getAudioData();
+  uint8_t samplePeak = *(uint8_t*)um_data->u_data[3];
+
+  constexpr uint16_t range = 75;       // width of wave in each direction
+  uint16_t center       = SEGLEN / 2;  // center of strip
+
+  if (SEGENV.call == 0) {
+    SEGENV.step = 0;
+    SEGENV.aux0 = range + (SEGLEN >> 1) + 1; // wave inactive
+  }
+
+  // background based on aurora palette movement
+  SEGENV.step += (SEGMENT.speed >> 1) + 1; // slower background
+  uint16_t t = SEGENV.step;
+  for (uint16_t i = 0; i < SEGLEN; i++) {
+    uint8_t index = ((i * 255) / SEGLEN + (t >> 3)) & 0xFF;
+    uint8_t bri = sin8_t(i * 8 + t);
+    SEGMENT.setPixelColor(i, SEGMENT.color_from_palette(index, false, PALETTE_SOLID_WRAP, 0, bri));
+  }
+
+  if (samplePeak && SEGENV.aux0 > range + (SEGLEN >> 1)) {
+    SEGENV.aux0 = 0; // trigger wave
+  }
+
+  if (SEGENV.aux0 <= range + (SEGLEN >> 1)) {
+    uint16_t distMax = (SEGLEN >> 1) + range;
+    uint8_t amplitude = 255 - (SEGENV.aux0 * 255 / distMax);
+
+    for (uint16_t i = 0; i < SEGLEN; i++) {
+      int16_t dist = abs((int16_t)i - (int16_t)center);
+      if (dist >= SEGENV.aux0 && dist <= SEGENV.aux0 + range) {
+        uint16_t local = dist - SEGENV.aux0;
+        uint8_t bright = (uint8_t)((uint32_t)amplitude * (range - local) / range);
+        // create a "hole" at start and end for better visibility
+        if (local < 2 || local > range - 2) {
+          SEGMENT.setPixelColor(i, BLACK);
+        } else {
+          SEGMENT.setPixelColor(i, color_blend(SEGMENT.getPixelColor(i), WHITE, bright));
+        }
+      }
+    }
+
+    SEGENV.aux0 += 1 + (SEGMENT.speed >> 6); // slower wave progress
+  }
+
+  return FRAMETIME;
+}
+static const char _data_FX_MODE_WATER_WAVE_SOUND[] PROGMEM = "Water Wave Sound@;;";
+
+
 #ifndef WLED_DISABLE_2D
 ///////////////////////////////////////////////////////////////////////////////
 //***************************  2D routines  ***********************************
@@ -10767,6 +10821,7 @@ void WS2812FX::setupEffectData() {
   addEffect(FX_MODE_FLOWSTRIPE, &mode_FlowStripe, _data_FX_MODE_FLOWSTRIPE);
   addEffect(FX_MODE_WAVESINS, &mode_wavesins, _data_FX_MODE_WAVESINS);
   addEffect(FX_MODE_ROCKTAVES, &mode_rocktaves, _data_FX_MODE_ROCKTAVES);
+  addEffect(FX_MODE_WATER_WAVE_SOUND, &mode_water_wave_sound, _data_FX_MODE_WATER_WAVE_SOUND);
 
   // --- 2D  effects ---
 #ifndef WLED_DISABLE_2D

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -373,7 +373,8 @@ extern byte realtimeMode;           // used in getMappedPixelIndex()
 #define FX_MODE_PS1DSONICBOOM          215
 #define FX_MODE_PS1DSPRINGY            216
 #define FX_MODE_PARTICLEGALAXY         217
-#define MODE_COUNT                     218
+#define FX_MODE_WATER_WAVE_SOUND       218
+#define MODE_COUNT                     219
 
 
 #define BLEND_STYLE_FADE            0x00  // universal


### PR DESCRIPTION
## Summary
- tweak MODE_WATER_WAVE_SOUND to blend aurora-style background with audio waves
- waves now expand from the center in both directions with gradual fade

## Testing
- `npm test` *(fails: test failed)*

------
https://chatgpt.com/codex/tasks/task_e_68714a411230832f953ca1b03cd0be1b